### PR TITLE
Fix: Dockerコンテナセットアップの改善とdockerグループ権限処理の追加

### DIFF
--- a/1_install_azazel.sh
+++ b/1_install_azazel.sh
@@ -71,4 +71,4 @@ echo "[INFO] ディレクトリを作成中..." | tee -a "$ERROR_LOG"
 mkdir -p /opt/azazel/{bin,config,logs,data,containers}
 chown -R "$(whoami)":"$(whoami)" /opt/azazel
 
-echo "[SUCCESS] インストール完了！次に ./setup_containers.sh を実行してください。" | tee -a "$ERROR_LOG"
+echo "[SUCCESS] インストール完了！次に ./2_setup_containers.sh を実行してください。" | tee -a "$ERROR_LOG"

--- a/2_setup_containers.sh
+++ b/2_setup_containers.sh
@@ -45,7 +45,7 @@ services:
       - azazel_net
 
   vector:
-    image: timberio/vector:latest
+    image: timberio/vector:0.37.0-alpine
     container_name: azazel_vector
     restart: always
     volumes:
@@ -74,4 +74,25 @@ if ! docker-compose up -d; then
     log_and_exit "Dockerコンテナの起動に失敗しました。" "docker logs azazel_postgres などでログを確認してください。"
 fi
 
-echo "[SUCCESS] Dockerコンテナのセットアップ完了！次に ./configure_services.sh を実行してください。" | tee -a "$ERROR_LOG"
+
+# 現在のユーザーを docker グループに追加（未所属の場合のみ）
+CURRENT_USER="${SUDO_USER:-$USER}"
+
+if id -nG "$CURRENT_USER" | grep -qw docker; then
+    echo "[INFO] $CURRENT_USER はすでに docker グループに所属しています。"
+else
+    echo "[INFO] $CURRENT_USER を docker グループに追加します。"
+    sudo usermod -aG docker "$CURRENT_USER"
+    echo "[SUCCESS] docker グループに追加しました。"
+
+    echo ""
+    echo "⚠️  変更を反映させるには、以下を実行してください："
+    echo ""
+    echo "   newgrp docker"
+    echo "     または"
+    echo "   一度ログアウトして再ログイン"
+    echo ""
+    echo "[INFO] 処理はここで終了します。以降の操作は新しいセッションで実行してください。"
+    exit 0
+fi
+echo "[INFO] Dockerコンテナのセットアップ完了！次に ./3_configure_services.sh を実行してください。" | tee -a "$ERROR_LOG"

--- a/retrieve_runtime.sh
+++ b/retrieve_runtime.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# === Azazel Runtime Retrieval Script ===
+# /opt/azazel の内容をローカルディレクトリ azazel/azazel_runtime にコピーします。
+# 動作確認やローカルでのファイル検証に使用します。
+
+set -e
+
+SRC_DIR="/opt/azazel"
+DEST_DIR="$PWD/azazel_runtime"
+
+echo "[INFO] Retrieving Azazel runtime from $SRC_DIR to $DEST_DIR"
+
+if [ ! -d "$SRC_DIR" ]; then
+    echo "[ERROR] $SRC_DIR が存在しません。Azazelがインストールされていない可能性があります。"
+    exit 1
+fi
+
+mkdir -p "$DEST_DIR"
+rsync -av --delete "$SRC_DIR"/ "$DEST_DIR"
+
+echo "[SUCCESS] Retrieval completed."


### PR DESCRIPTION
## 概要

以下の問題に対応するため、`2_setup_containers.sh` を中心に修正を行いました。

## 修正内容

- OpenCanary・Vector・PostgreSQL のコンテナをセットアップする `docker-compose.yml` を修正
- `timberio/vector:latest` が存在しないため `0.37.0-alpine` に変更
- `docker` グループに未所属のユーザーをスクリプト内で自動追加し、`newgrp docker` の案内後に終了
- `fluent-bit` インストール用の修正は前段階で対応済み（別スクリプト）

## 注意点

- `opencanary.conf` が未配置のため、`azazel_opencanary` は `Restarting` 状態（想定通り）
- この後のステップで設定ファイルを設置・動作確認を行う予定
