### PR TITLE
Suricataルール取得・動作確認に関する構成修正

### DIFF
--- a/azazel_runtime/config/suricata_minimal.yaml
+++ b/azazel_runtime/config/suricata_minimal.yaml
@@ -1,0 +1,48 @@
+%YAML 1.1
+---
+
+vars:
+  address-groups:
+    HOME_NET: "[192.168.0.0/16]"
+    EXTERNAL_NET: "any"
+
+default-rule-path: /var/lib/suricata/rules
+rule-files:
+  - suricata.rules
+
+af-packet:
+  - interface: wlan0
+    cluster-id: 99
+    cluster-type: cluster_flow
+    defrag: yes
+    use-mmap: yes
+    disable-promisc: no
+
+outputs:
+  - fast:
+      enabled: yes
+      filename: fast.log
+      append: yes
+
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve.json
+      types:
+        - alert:
+            tagged-packets: yes
+        - flow
+        - stats
+
+logging:
+  default-log-level: notice
+  outputs:
+    - console:
+        enabled: no
+    - file:
+        enabled: yes
+        level: info
+        filename: suricata.log
+
+classification-file: /etc/suricata/classification.config
+reference-config-file: /etc/suricata/reference.config


### PR DESCRIPTION
## 概要

Suricataのアラート検知動作を正常化するため、以下の修正・構成追加を行った。

- `suricata-update` によるルール取得と適用
- Suricataが実際にルールを読み込んでいなかった問題の修正
- アラート発生確認（curl / nmap テストによる動作検証）
- 軽量構成用の設定ファイル `suricata_minimal.yaml` を追加

---

## 変更内容

- `suricata-update enable-source et/open` により ET Open を有効化
- `/etc/suricata/suricata.yaml` にて `rule-files:` に `suricata.rules` を指定
- `filtered.rules` からの移行を考慮しつつ、最低限の構成で動作するテンプレートを作成
  - ファイル追加: `azazel_runtime/config/suricata_minimal.yaml`
- `af-packet:` 設定を `wlan0` に最適化し、`use-mmap` と `disable-promisc` を有効化
- `fast.log`, `eve.json(alert, flow, stats)` のみに限定し、不要な出力を削除

---

## 動作確認済み内容

- `curl http://testmynids.org/uid/index.html` にてアラート検出確認
- `nmap -sS` による SCAN アラート確認
- `/var/log/suricata/fast.log` へのアラート出力
- `/var/lib/suricata/rules/suricata.rules` が適用されていることを確認
- `rules_loaded > 0` を suricatasc にて確認済み

---

## 今後の対応（必要に応じて）

- `suricata_minimal.yaml` を自動で適用する選択肢の追加
- `filtered.rules` による軽量ルール抽出スクリプトとの連携
- Mattermost通知への連動（高優先度アラート時）

---

**Close #5**
