### PR TITLE
Vector本番構成に切り替え（Suricata/OpenCanaryログ集約 & ファイル出力設定）

### DIFF
--- a/azazel_runtime/config/fluentbit.conf
+++ b/azazel_runtime/config/fluentbit.conf
@@ -1,13 +1,45 @@
+##### INPUT: Suricata（eve.json） #####
 [INPUT]
-    Name tail
-    Path /var/log/suricata/eve.json
-    Tag suricata
+    Name   tail
+    Path   /var/log/suricata/eve.json
+    Tag    suricata
     Parser json
 
+##### INPUT: OpenCanary（JSONログ） #####
+[INPUT]
+    Name   tail
+    Path   /opt/azazel/logs/opencanary.log
+    Tag    opencanary
+    Parser json
+    Multiline       On
+    Multiline_Firstline  ^\d{4}-\d{2}-\d{2}
+
+##### FILTER: 任意でフィルタ追加可能（必要になったら） #####
+# 例：ログに `level` を追加、特定ログだけ選別、タグ変更など
+# [FILTER]
+#     Name modify
+#     Match *
+#     Add hostname azazel-pi5
+
+##### OUTPUT: Vector（すべてのログを送信） #####
 [OUTPUT]
-    Name http
-    Match suricata
-    Host 192.168.X.X
-    Port 8065
-    URI /hooks/XXXXX
+    Name   forward
+    Match  *
+    Host   vector
+    Port   24224
+
+##### OUTPUT: Mattermost（サンプル：suricataログのみ通報） #####
+[OUTPUT]
+    Name   http
+    Match  suricata
+    Host   192.168.X.X
+    Port   8065
+    URI    /hooks/XXXXX
     Format json
+
+##### OUTPUT: ノートPC向け（接続されているときのみ起動） #####
+# ここは rsync/scp 等のバッチで外出しするか、以下のようなログファイル出力も可
+# [OUTPUT]
+#     Name   file
+#     Match  *
+#     Path   /tmp/azazel_laptop_transfer.log

--- a/azazel_runtime/config/vector.toml
+++ b/azazel_runtime/config/vector.toml
@@ -1,13 +1,36 @@
-[sources.fluentbit]
-  type = "socket"
-  address = "0.0.0.0:24224"
-  mode = "udp"
+##### SOURCE: Suricata #####
+[sources.suricata]
+  type = "file"
+  include = ["/var/log/suricata/eve.json"]
+  read_from = "end"
+  ignore_older_secs = 86400
+  fingerprinting.strategy = "device_and_inode"
 
-[transforms.json_parse]
-  type = "json_parser"
-  inputs = ["fluentbit"]
+##### SOURCE: OpenCanary #####
+[sources.opencanary]
+  type = "file"
+  include = ["/opt/azazel/logs/opencanary.log"]
+  read_from = "end"
+  ignore_older_secs = 86400
+  fingerprinting.strategy = "device_and_inode"
 
+##### TRANSFORM: OpenCanaryだけを正規JSONにする #####
+[transforms.clean_opencanary]
+  type = "remap"
+  inputs = ["opencanary"]
+  source = '''
+  .log = encode_json(.)
+  '''
+
+##### SINK: ファイル出力 #####
 [sinks.file]
   type = "file"
-  inputs = ["json_parse"]
+  inputs = ["suricata", "clean_opencanary"]
   path = "/logs/azazel.log"
+  encoding.codec = "json"
+
+[sinks.stdout_debug]
+  type = "console"
+  inputs = ["clean_opencanary"]
+  target = "stdout"
+  encoding.codec = "json"

--- a/azazel_runtime/containers/docker-compose.yml
+++ b/azazel_runtime/containers/docker-compose.yml
@@ -22,6 +22,9 @@ services:
     volumes:
       - /opt/azazel/config/vector.toml:/etc/vector/vector.toml
       - /opt/azazel/logs:/logs
+      - /var/log/suricata:/var/log/suricata  # Suricataのログディレクトリをマウント
+      - /opt/azazel/logs:/opt/azazel/logs    # OpenCanaryのログディレクトリをマウント      
+    command: --config /etc/vector/vector.toml
     networks:
       - azazel_net
 
@@ -38,7 +41,7 @@ services:
       - "2222:2222"   # SSH (HoneyPot)
     networks:
       - azazel_net
-
+  
 networks:
   azazel_net:
     driver: bridge


### PR DESCRIPTION
- vector.toml を本番用に修正（remap適用、azazel.log出力、read_from = "end"）
- docker-compose.yml にログマウントと再構成を反映