### PR TITLE
インストーラ3種を統合し、README.mdとsetup.mdを整備（多言語対応・構成順最適化）

### DIFF
--- a/3_configure_services.sh
+++ b/3_configure_services.sh
@@ -47,7 +47,6 @@ fi
 # === ディレクトリの所有権とパーミッション調整 ===
 chown -R mattermost:mattermost /opt/mattermost
 chmod 750 /opt/mattermost/config
-chmod 640 /opt/mattermost/config/config.json
 
 # === jq が未インストールなら導入 ===
 if ! command -v jq &>/dev/null; then
@@ -59,11 +58,15 @@ fi
 echo "[INFO] config.json に SiteURL / DataSource を自動設定..." | tee -a "$ERROR_LOG"
 IPADDR=$(hostname -I | awk '{print $1}')
 SITEURL="http://${IPADDR}:8065"
-DATASOURCE="postgres://mmuser:securepassword@localhost:5432/mattermost?sslmode=disable"
+DATASOURCE="postgres://mmuser:securepassword@azazel_postgres:5432/mattermost?sslmode=disable"
 CONFIG_JSON="/opt/mattermost/config/config.json"
 
 jq ".ServiceSettings.SiteURL = \"${SITEURL}\" | .SqlSettings.DataSource = \"${DATASOURCE}\"" \
     "$CONFIG_JSON" > /tmp/config.tmp && mv /tmp/config.tmp "$CONFIG_JSON"
+
+# 所有権とパーミッション修正（重要）
+chown mattermost:mattermost "$CONFIG_JSON"
+chmod 640 "$CONFIG_JSON"
 
 echo "[SUCCESS] config.json に反映完了: SiteURL=${SITEURL}" | tee -a "$ERROR_LOG"
 

--- a/README.md
+++ b/README.md
@@ -84,14 +84,54 @@ These principles converge in Azazel’s design: **defense is not about passive p
 
 ## インストール / Installation
 
+### 🔧 必要条件 / Requirements
+- Raspberry Pi OS (64bit Lite)
+- インターネット接続 / Internet connection
+- 管理者権限（sudo） / Administrator privileges (sudo)
+
+### 🛠️ 導入手順 / Setup Instructions
+
 ```bash
 git clone https://github.com/01rabbit/Azazel.git azazel
 cd azazel
-./install.sh
+sudo bash install_azazel.sh          # 日本語出力（デフォルト）
+sudo bash install_azazel.sh --lang=en # 英語出力
 ```
 
-※ 詳細は `docs/setup.md` を参照してください。  
-See `docs/setup.md` for full setup instructions.
+※ `--lang=en` オプションを付けると、出力メッセージが英語になります。  
+Use `--lang=en` for English log/output.
+
+- スクリプトは以下を自動で実行します：  
+  *The script automatically performs the following:*
+  - パッケージのインストールとシステム更新 / Install packages and update system
+  - Suricataのルール初期化 / Initialize Suricata rules
+  - 必要な設定ファイルのコピー（Vector, OpenCanaryなど） / Copy required config files (Vector, OpenCanary, etc.)
+  - Dockerコンテナ（PostgreSQL, Vector, OpenCanary）の起動 / Start Docker containers (PostgreSQL, Vector, OpenCanary)
+  - Mattermostの展開、設定（config.json自動編集）、systemd起動登録 / Deploy Mattermost, auto-configure `config.json`, and register with systemd
+
+ログは `/opt/azazel/logs/install_errors.log` に保存されます。  
+*Installation logs are saved to `/opt/azazel/logs/install_errors.log`.*
+
+### ✅ 導入後確認 / Post-Install Check
+- Mattermost にブラウザでアクセス：  
+  *Access Mattermost in your browser:*
+  ```
+  http://<your Raspberry Pi's IP address>:8065
+  ```
+- コンテナの状態を確認：  
+  *Check container status:*
+  ```bash
+  cd /opt/azazel/containers
+  docker-compose ps
+  ```
+- サービス状態：  
+  *Check Mattermost service status:*
+  ```bash
+  systemctl status mattermost
+  ```
+
+詳細な構成内容や設定ファイルの説明は `docs/setup.md` を参照してください。  
+See `docs/setup.md` for full setup instructions and configuration details.
 
 ---
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,101 @@
+## 🧩 システム構成 / System Architecture
+
+Azazelは以下のコンポーネントで構成されます：  
+*Azazel is composed of the following components:*
+
+- OpenCanary（ハニーポットサービス） / Honeypot service
+- Vector（ログ収集と転送） / Log collection and forwarding
+- PostgreSQL（Mattermost用DB） / Database for Mattermost
+- Mattermost（通知UI） / Notification and collaboration UI
+
+各サービスはDockerコンテナ上で稼働し、ホスト上で制御・通知連携が可能です。  
+*All components run in Docker containers and are managed and integrated via the host system.*
+
+---
+
+## ⚙️ 設定ファイルの説明 / Configuration Files
+
+### `/opt/azazel/config/opencanary.conf`
+- 各種疑似サービス（SSH, HTTPなど）の有効化・ログ出力設定  
+  *Enables simulated services like SSH/HTTP and sets log output settings.*
+- `device.node_id` は一意な識別子  
+  *`device.node_id` must be unique for each instance.*
+
+### `/opt/azazel/config/vector.toml`
+- Vectorが収集するログソース（例：OpenCanaryログ、Suricataログ）  
+  *Defines sources Vector will collect logs from (e.g., OpenCanary, Suricata).* 
+- 出力先はコンソール、ファイル、もしくは将来的にSIEM連携  
+  *Output can be console, file, or eventually a SIEM system.*
+
+### `/opt/mattermost/config/config.json`
+- `install_azazel.sh` により `SiteURL` や `DataSource` が自動設定される  
+  *`install_azazel.sh` automatically configures `SiteURL` and `DataSource`.*
+- 手動でSMTPやファイルストレージなど追加設定可能  
+  *You can manually configure SMTP, file storage, etc.*
+
+---
+
+## 🚦 起動順と依存関係 / Startup Sequence and Dependencies
+
+- `/opt/azazel/config/*` の設定ファイルは `docker-compose up` の**前に配置**する必要があります  
+  *Configuration files must be placed before running `docker-compose up`.*
+- Mattermost は PostgreSQL が `Up` になってから systemd 経由で起動  
+  *Mattermost requires PostgreSQL to be running before its own startup.*
+- `config.json` 編集後は `chown/chmod` を適切に行わないと起動失敗します  
+  *Ensure `config.json` has correct ownership and permissions after editing.*
+
+---
+
+## 🛠️ カスタマイズ例 / Customization Examples
+
+- `docker-compose.yml` 内の IP アドレスを固定化（例：172.16.10.10）  
+  *Set static IP addresses in `docker-compose.yml` (e.g., 172.16.10.10).* 
+- OpenCanary のサービス追加（Telnet, SMBなど）  
+  *Enable additional OpenCanary services (e.g., Telnet, SMB).* 
+- Vector のログ出力形式を JSON → text に変更  
+  *Change Vector log output format from JSON to plain text.*
+
+---
+
+## 🧪 トラブルシュート / Troubleshooting
+
+| 問題 / Problem | 原因 / Cause | 解決策 / Solution |
+|------|------|--------|
+| OpenCanary が Restarting を繰り返す / OpenCanary keeps restarting | `/root/.opencanary.conf` がディレクトリ / It is a directory | `rm -rf` して再起動 / Remove and restart |
+| Vector が `is a directory` エラー / Vector "is a directory" error | `/etc/vector/vector.toml` が誤ってディレクトリ / It is incorrectly a directory | 正しいファイルを再配置 / Replace with correct file |
+| Mattermost 起動失敗 `exit-code` / Mattermost fails with exit-code | `config.json` のパーミッション or DB接続誤り / Permission or DB access error | `chown` + `azazel_postgres` に修正 / Fix ownership and DB host |
+
+---
+
+## 🔁 メンテナンスと更新 / Maintenance
+
+- Suricataルール更新：  
+  *Update Suricata rules:*
+```bash
+sudo suricata-update
+```
+
+- コンテナの再起動：  
+  *Restart containers:*
+```bash
+cd /opt/azazel/containers
+sudo docker-compose down && sudo docker-compose up -d
+```
+
+- Mattermostのログ確認：  
+  *Check Mattermost logs:*
+```bash
+sudo journalctl -u mattermost -e
+```
+
+---
+
+## 📘 その他 / Notes
+
+- `.env` や `.local` 設定などを活用することで、構成をより柔軟にできます  
+  *You can further customize the setup using `.env` or `.local` files.*
+- Mattermostの管理者アカウント作成は初回ブラウザアクセス時に行います  
+  *Create the Mattermost admin account via the browser on first access.*
+
+For advanced use, consider adjusting `.env` or mounting your own configuration volume.
+

--- a/install_azazel.sh
+++ b/install_azazel.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+# ===============================
+# Azazel 統合インストーラ with 多言語対応
+# ===============================
+
+# ===== 言語オプション処理（--lang=en で英語出力） =====
+LANG_OPTION="ja"  # デフォルトは日本語
+for arg in "$@"; do
+  case $arg in
+    --lang=*)
+      LANG_OPTION="${arg#*=}"
+      ;;
+  esac
+done
+
+# ===== メッセージ辞書（日本語/英語） =====
+if [[ "$LANG_OPTION" == "en" ]]; then
+  MSG_REQUIRE_ROOT="[ERROR] This script must be run as root."
+  MSG_EXAMPLE_SUDO="       Example: sudo $0"
+  MSG_ERROR_GENERIC="[ERROR] An error occurred. See the log for details."
+  MSG_LOG_PATH="Details:"
+  MSG_START_INSTALL="[INFO] Starting Azazel installation"
+  MSG_UPDATE_SYSTEM="[INFO] Updating system and installing dependencies..."
+  MSG_SURICATA_RULES="[INFO] Fetching initial Suricata rules..."
+  MSG_CREATE_DIRS="[INFO] Creating Azazel directory structure..."
+  MSG_COPY_CONFIGS="[INFO] Copying configuration files before Docker startup..."
+  MSG_SETUP_DOCKER="[INFO] Deploying docker-compose and starting containers..."
+  MSG_MATTERMOST_SETUP="[INFO] Deploying Mattermost to /opt..."
+  MSG_CONFIG_UPDATED="[SUCCESS] config.json updated with SiteURL and DataSource."
+  MSG_MATTERMOST_STARTED="[SUCCESS] Mattermost service started successfully."
+  MSG_INSTALL_DONE="[SUCCESS] Azazel setup is complete!"
+else
+  MSG_REQUIRE_ROOT="[ERROR] このスクリプトは管理者権限で実行する必要があります。"
+  MSG_EXAMPLE_SUDO="       例: sudo $0"
+  MSG_ERROR_GENERIC="[ERROR] スクリプトの実行中にエラーが発生しました。詳細はログを確認してください。"
+  MSG_LOG_PATH="詳細:"
+  MSG_START_INSTALL="[INFO] Azazel 統合インストール開始"
+  MSG_UPDATE_SYSTEM="[INFO] システム更新と必要パッケージのインストール..."
+  MSG_SURICATA_RULES="[INFO] Suricata ルールを初回取得中..."
+  MSG_CREATE_DIRS="[INFO] ディレクトリ構成作成中..."
+  MSG_COPY_CONFIGS="[INFO] コンテナ起動前に設定ファイルをコピー..."
+  MSG_SETUP_DOCKER="[INFO] docker-compose.yml を配置し、コンテナ起動中..."
+  MSG_MATTERMOST_SETUP="[INFO] Mattermost を /opt に展開中..."
+  MSG_CONFIG_UPDATED="[SUCCESS] config.json に SiteURL/DataSource を反映しました。"
+  MSG_MATTERMOST_STARTED="[SUCCESS] Mattermost サービスが正常に起動しました。"
+  MSG_INSTALL_DONE="[SUCCESS] Azazel 環境の構築が完了しました！"
+fi
+
+# === 管理者権限チェック ===
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e "\e[91m$MSG_REQUIRE_ROOT\e[0m"
+    echo "$MSG_EXAMPLE_SUDO"
+    exit 1
+fi
+
+# === エラーハンドリング ===
+set -e
+ERROR_LOG="/opt/azazel/logs/install_errors.log"
+mkdir -p /opt/azazel/logs
+trap 'echo -e "\e[91m$MSG_ERROR_GENERIC\e[0m $MSG_LOG_PATH $ERROR_LOG" | tee -a "$ERROR_LOG"' ERR
+
+PROJECT_ROOT="$(cd "$(dirname "$0")" && pwd)"
+echo -e "\e[96m$MSG_START_INSTALL\e[0m ($(date))" | tee -a "$ERROR_LOG"
+
+log_and_exit() {
+    echo -e "\e[91m[ERROR]\e[0m $1" | tee -a "$ERROR_LOG"
+    echo -e "\e[93m[INFO]\e[0m 解決策: $2" | tee -a "$ERROR_LOG"
+    exit 1
+}
+
+# === システムアップデートと依存パッケージ ===
+echo -e "\e[96m$MSG_UPDATE_SYSTEM\e[0m" | tee -a "$ERROR_LOG"
+apt update && apt upgrade -y
+apt install -y curl wget git docker.io docker-compose python3 python3-pip suricata iptables-persistent jq
+
+# === Suricata ルール初期取得 ===
+echo -e "\e[96m$MSG_SURICATA_RULES\e[0m" | tee -a "$ERROR_LOG"
+suricata-update || log_and_exit "Suricataルールの取得に失敗" "インターネット接続と suricata-update を確認"
+
+# === Azazel ディレクトリ構成作成 ===
+echo -e "\e[96m$MSG_CREATE_DIRS\e[0m" | tee -a "$ERROR_LOG"
+mkdir -p /opt/azazel/{bin,config,logs,data,containers}
+chown -R "$(whoami)":"$(whoami)" /opt/azazel
+
+# === 設定ファイルの先行配置（重要: コンテナ起動前） ===
+echo -e "\e[96m$MSG_COPY_CONFIGS\e[0m" | tee -a "$ERROR_LOG"
+cp "$PROJECT_ROOT/config/vector.toml" /opt/azazel/config/
+cp "$PROJECT_ROOT/config/opencanary.conf" /opt/azazel/config/
+
+# === docker-compose.yml の配置と Docker コンテナ起動 ===
+echo -e "\e[96m$MSG_SETUP_DOCKER\e[0m" | tee -a "$ERROR_LOG"
+cp "$PROJECT_ROOT/config/docker-compose.yml" /opt/azazel/containers/docker-compose.yml
+cd /opt/azazel/containers
+docker-compose up -d || log_and_exit "Dockerコンテナ起動に失敗" "docker logs を確認してください"
+
+# === Mattermost セットアップ ===
+echo -e "\e[96m$MSG_MATTERMOST_SETUP\e[0m" | tee -a "$ERROR_LOG"
+cd /opt
+wget https://releases.mattermost.com/9.0.0/mattermost-9.0.0-linux-arm64.tar.gz
+ tar -xzf mattermost-9.0.0-linux-arm64.tar.gz
+rm mattermost-9.0.0-linux-arm64.tar.gz
+mkdir -p /opt/mattermost/data
+
+if ! id mattermost &>/dev/null; then
+    useradd --system --user-group mattermost
+fi
+
+chown -R mattermost:mattermost /opt/mattermost
+chmod 750 /opt/mattermost/config
+
+IPADDR=$(hostname -I | awk '{print $1}')
+SITEURL="http://${IPADDR}:8065"
+DATASOURCE="postgres://mmuser:securepassword@azazel_postgres:5432/mattermost?sslmode=disable"
+CONFIG_JSON="/opt/mattermost/config/config.json"
+
+jq ".ServiceSettings.SiteURL = \"${SITEURL}\" | .SqlSettings.DataSource = \"${DATASOURCE}\"" \
+    "$CONFIG_JSON" > /tmp/config.tmp && mv /tmp/config.tmp "$CONFIG_JSON"
+
+chown mattermost:mattermost "$CONFIG_JSON"
+chmod 640 "$CONFIG_JSON"
+echo -e "\e[92m$MSG_CONFIG_UPDATED\e[0m"
+
+cp "$PROJECT_ROOT/config/mattermost.service" /etc/systemd/system/mattermost.service
+systemctl daemon-reload
+systemctl enable mattermost
+systemctl start mattermost
+
+if systemctl is-active --quiet mattermost; then
+    echo -e "\e[92m$MSG_MATTERMOST_STARTED\e[0m"
+else
+    log_and_exit "Mattermost サービスの起動に失敗" "systemctl status mattermost を確認してください。"
+fi
+
+echo -e "\e[92m$MSG_INSTALL_DONE\e[0m" | tee -a "$ERROR_LOG"


### PR DESCRIPTION
### 🎯 概要 / Summary

Azazelのセットアップに関する3つのインストーラースクリプト（install, setup_containers, configure_services）を1つに統合し、READMEおよび新規ドキュメント（docs/setup.md）を整備しました。

---

### ✅ 主な変更点 / Main Changes

#### 🧩 インストーラ統合
- 3つのスクリプトを `install_azazel.sh` に統合
- サービス起動前に設定ファイルを生成するのではなく、`config/` ディレクトリからコピーする方式に変更  
  → これにより、**Dockerコンテナ起動前に設定が反映されるようになり、初回起動エラーを防止**
- `--lang=en` による英語出力対応（デフォルトは日本語）

#### 📘 README.md 更新
- 統合インストーラの利用手順を反映
- `docker-compose` を使用していることを明示し、`docker-compose ps` での状態確認を記載
- すべてのセクションに日本語＋英語の併記を実装

#### 📄 docs/setup.md 新規作成
- システム構成、設定ファイルの説明、起動順序、カスタマイズ例、トラブルシュートを網羅
- すべて日英併記で記載し、実運用向けの詳細マニュアルとして活用可能

---

### 📌 補足
- 今後の拡張として `.env` や構成図対応などを検討予定
- 構成ファイル変更を前提とした再インストールやCIへの活用にも備えた構成へ整理済み
