### PR TITLE
Fix typo in installation guide

### DIFF
--- a/docs/Minimal_Install_and_Verification.md
+++ b/docs/Minimal_Install_and_Verification.md
@@ -47,7 +47,7 @@ Start RaspAP related services
 
 ```bash
 sudo systemctl enable hostapd
-dudo systemctl enable dnsmasq
+sudo systemctl enable dnsmasq
 sudo systemctl restart lighttpd
 ```
 


### PR DESCRIPTION
## Summary
- correct typo in `Minimal_Install_and_Verification.md` replacing `dudo` with `sudo`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452f2818988323b80e49676307e98a