### PR TITLE
docs: Azazel-Fabric 最新リリース表記を v0.3.0 に更新

### DIFF
--- a/docs/products/azazel-fabric.md
+++ b/docs/products/azazel-fabric.md
@@ -36,7 +36,7 @@ The shared contracts library for the Azazel series — the common language spoke
 
 ## Package and License
 
-- Distribution name `azazel-fabric`, import as `azazel_fabric` (from v0.3.0; the v0.1.0/v0.2.0 tags keep the former `azazel-common` / `azazel_common` identifiers). Latest tagged release: v0.2.0.
+- Distribution name `azazel-fabric`, import as `azazel_fabric` (from v0.3.0; the v0.1.0/v0.2.0 tags keep the former `azazel-common` / `azazel_common` identifiers). Latest tagged release: v0.3.0.
 - License: TBD (no LICENSE file yet).
 
 See also: [Product Map](product-map.md) | [Naming Convention](../specs/naming.md)


### PR DESCRIPTION
## Summary
- Change type: [x] Variant(製品ページの版数更新)

Azazel-Fabric の v0.3.0 タグ発行を受け、製品ページの「Latest tagged release」を v0.2.0 → v0.3.0 に更新(1行)。

## Checklist
- [x] Updated nav in `_config.yml` if needed — 不要
- [ ] Added/updated diagrams — 対象外
- [x] No broken internal links — 既存リンクのみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQf8XoJkM1vVE57jAYmi94

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQf8XoJkM1vVE57jAYmi94)_