### PR TITLE
docs: Tool Family表をシリーズ一覧の正典として拡充

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,16 @@ See also: [Deterministic Defense](docs/concepts/deterministic-defense.md) | [Off
 
 ## Tool Family
 
-| Project | Former Name | Role | Target |
-|---|---|---|---|
-| [Azazel-Edge](https://github.com/01rabbit/Azazel-Edge) | Azazel-Pi | Field-deployable edge SOC/NOC and scapegoat gateway | Raspberry Pi 5 / edge networks |
-| [Azazel-Gadget](https://github.com/01rabbit/Azazel-Gadget) | Azazel-Zero | Portable tactical defense on untrusted Wi-Fi | Raspberry Pi Zero 2 W / personal use |
-| [Azazel-Knowledge Advisor](https://github.com/01rabbit/Azazel-Knowledge) | Azazel-CTI | Advisory-only tactical CTI node (never commands; edge stays functional if it is absent, slow, or wrong) | Raspberry Pi 4 / on-premises |
-| [Azazel-Fabric Contract](https://github.com/01rabbit/Azazel-Fabric) | Azazel-Common | Shared contracts library for the series (common language, not a decision core) | Cross-repository |
-| Azazel (this repository) | Legacy doctrine hub | Doctrine, architecture, naming, and product-family entry point | Cross-repository |
+| Project | Designation | Codename | Former Name | Role | Target |
+|---|---|---|---|---|---|
+| [Azazel-Edge Gateway](https://github.com/01rabbit/Azazel-Edge) | AZ-01 | `SENTINEL` | Azazel-Pi | Field-deployable edge SOC/NOC and scapegoat gateway (deterministic arbiter) | Raspberry Pi 5 / edge networks |
+| [Azazel-Gadget Shield](https://github.com/01rabbit/Azazel-Gadget) | AZ-02 | `TACMOD` | Azazel-Zero | Portable tactical defense on untrusted Wi-Fi | Raspberry Pi Zero 2 W / personal use |
+| Azazel-Boot Probe | AZ-03 | — | Azazel-USB | Reserved bootable rapid-response class; no repository yet | Portable USB boot |
+| [Azazel-Knowledge Advisor](https://github.com/01rabbit/Azazel-Knowledge) | AZ-04 | `GRIMOIRE` | Azazel-CTI | Advisory-only tactical CTI node (never commands; the edge stays functional if it is absent, slow, or wrong) | Raspberry Pi 4 / on-premises |
+| [Azazel-Fabric Contract](https://github.com/01rabbit/Azazel-Fabric) | AZ-05 | `COVENANT` | Azazel-Common | Shared contracts library — the series' common language, not a decision core (`azazel_fabric`; Edge is the largest consumer, Gadget fully migrated) | Cross-repository |
+| Azazel (this repository) | — | — | — | Doctrine, architecture, naming, and product-family entry point | Cross-repository |
+
+Edge, Gadget, and Boot are the defensive deployment classes; Fabric and Knowledge are the support classes that make the Azazel System work as a series.
 
 Legacy alias mapping: `Azazel-Pi -> Azazel-Edge (formerly)`, `Azazel-Zero -> Azazel-Gadget (formerly)`, `Azazel-USB -> Azazel-Boot (same meaning)`, `Azazel-CTI -> Azazel-Knowledge (formerly, working name)`, `Azazel-Common -> Azazel-Fabric (formerly)`.
 


### PR DESCRIPTION
## Summary
- Change type: [x] Spec(シリーズ一覧の正典化)

オーナー指摘への対応:製品リポジトリ(Edge)のREADMEにあったシリーズ一覧表は傘リポジトリの責務であるべき。

- Tool Family表を拡充:**Designation(AZ-01〜05)・Codename(SENTINEL/TACMOD/—/GRIMOIRE/COVENANT)列を追加**、Azazel-Boot(AZ-03, 予約)行を追加、正式名表記(Gateway/Shield/Advisor/Contract)に統一
- 「防御展開クラス(Edge/Gadget/Boot)と支援クラス(Fabric/Knowledge)」の一文を追加(naming.mdと同一表現)
- Edge側の一覧表撤去は対になるEdge PRで実施

## Checklist
- [x] Updated nav in `_config.yml` if needed — 不要(README のみ)
- [ ] Added/updated diagrams — 対象外
- [x] No broken internal links — 外部リンクのみ、実在確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQf8XoJkM1vVE57jAYmi94

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQf8XoJkM1vVE57jAYmi94)_