### PR TITLE
docs: バッジ完成・ライセンスマトリクスMIT統一・SECURITY/CONTRIBUTING整備

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to Azazel
+
+## Before you start
+
+This is the doctrine hub: README.md and `docs/specs/naming.md` are canonical for the whole Azazel series. Read them first.
+
+## Branch naming
+
+`<type>/<short-description>`
+
+Examples: `docs/products-index-refresh`, `naming/az-06-designation`, `site/nav-cleanup`
+
+## Commit message format
+
+`<type>(<scope>): <summary>`
+
+- type: `docs` / `fix` / `chore`
+- scope: `docs` / `naming` / `products` / `philosophy` / `concepts` / `site`
+
+## Pull request rules
+
+- 1 PR = 1 purpose. Do not mix unrelated changes.
+- Every PR must include:
+  - [ ] All internal links resolve (no broken relative paths)
+  - [ ] `_config.yml` nav updated if a page moved or was added/removed
+  - [ ] `docs/index_ja.md` updated when `docs/index.md` changes (JA mirror stays in sync)
+  - [ ] Naming-spec compliance: no new Form/Role word without updating `docs/specs/naming.md` first; no restricted terms (e.g. "Jamming")
+
+## What not to do (requires owner sign-off)
+
+- Do not change the naming spec (`docs/specs/naming.md`), the License Matrix, or any `AZ-xx` designation without owner sign-off.
+- Do not add product code here. Product implementation belongs in the product repositories (Azazel-Edge, Azazel-Gadget, Azazel-Knowledge, Azazel-Fabric).
+
+## License
+
+Contributions are accepted under Apache-2.0, the license of this repository.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@
 
 [![Azazel-Edge release](https://img.shields.io/github/v/release/01rabbit/Azazel-Edge?display_name=tag&label=Azazel-Edge&color=00c2d7)](https://github.com/01rabbit/Azazel-Edge/releases)
 [![Azazel-Gadget release](https://img.shields.io/github/v/release/01rabbit/Azazel-Gadget?display_name=tag&label=Azazel-Gadget&color=00c2d7)](https://github.com/01rabbit/Azazel-Gadget/releases)
+[![Azazel-Knowledge CI](https://img.shields.io/github/actions/workflow/status/01rabbit/Azazel-Knowledge/test.yml?label=Azazel-Knowledge%20CI)](https://github.com/01rabbit/Azazel-Knowledge/actions)
+[![Azazel-Fabric release](https://img.shields.io/github/v/release/01rabbit/Azazel-Fabric?display_name=tag&label=Azazel-Fabric&color=00c2d7)](https://github.com/01rabbit/Azazel-Fabric/releases)
 [![Azazel-Edge release date](https://img.shields.io/github/release-date/01rabbit/Azazel-Edge?label=Azazel-Edge%20updated)](https://github.com/01rabbit/Azazel-Edge/releases)
 [![Azazel-Gadget release date](https://img.shields.io/github/release-date/01rabbit/Azazel-Gadget?label=Azazel-Gadget%20updated)](https://github.com/01rabbit/Azazel-Gadget/releases)
+[![Azazel-Knowledge last commit](https://img.shields.io/github/last-commit/01rabbit/Azazel-Knowledge?label=Azazel-Knowledge%20updated)](https://github.com/01rabbit/Azazel-Knowledge/commits/main)
+[![Azazel-Fabric release date](https://img.shields.io/github/release-date/01rabbit/Azazel-Fabric?label=Azazel-Fabric%20updated)](https://github.com/01rabbit/Azazel-Fabric/releases)
 
 Azazel is a cyber defense doctrine and tool family built around one principle: do not merely block the attacker; bind them, slow them, observe them, and buy time.
 
@@ -72,6 +76,8 @@ Azazel is the doctrine. Azazel-Edge and Azazel-Gadget are concrete implementatio
 - [Products](docs/products/README.md)
 - [Naming and Terminology](docs/specs/naming.md)
 - [Existing Architecture Docs](docs/architecture/overview.md)
+- [Contributing](CONTRIBUTING.md)
+- [Security Policy](SECURITY.md)
 
 ## Conference / Arsenal Visitor Path
 
@@ -94,4 +100,4 @@ Azazel is the doctrine. Azazel-Edge and Azazel-Gadget are concrete implementatio
 - `01rabbit/Azazel-Edge`: MIT
 - `01rabbit/Azazel-Gadget`: MIT
 - `01rabbit/Azazel-Knowledge`: MIT
-- `01rabbit/Azazel-Fabric`: TBD
+- `01rabbit/Azazel-Fabric`: MIT

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,26 @@
 # Security Policy
 
-- Vulnerability reports: open a PRIVATE security advisory.
-- Do not disclose until a coordinated note is published.
+This repository is the Azazel documentation and doctrine hub; product code and its own security surface live in the product repositories (Azazel-Edge, Azazel-Gadget, Azazel-Knowledge, Azazel-Fabric).
+
+## Reporting a Vulnerability
+
+- Report privately via GitHub Security Advisories: https://github.com/01rabbit/Azazel/security/advisories/new
+- Do NOT open public issues for suspected vulnerabilities.
+- Include: affected repository/version or commit, environment, reproduction steps, impact assessment.
+- No bug bounty is offered; reporters are credited in the coordinated note unless they prefer otherwise.
+
+## Response Expectations
+
+- Acknowledgement within 7 days; initial assessment within 14 days.
+- Coordinated disclosure: please hold publication until a fix or advisory note is published.
+
+## Scope
+
+- This repository: site/documentation issues (e.g., content injection via the Pages site, leaked secrets in docs).
+- Product vulnerabilities belong in the product repository's own policy:
+  Azazel-Edge / Azazel-Gadget / Azazel-Knowledge / Azazel-Fabric (each has SECURITY.md).
+- Ecosystem-wide or cross-repository coordination issues may be reported here.
+
+## Supported Versions
+
+- The `main` branch of each repository, plus each product's latest tagged release.

--- a/docs/about/credits.md
+++ b/docs/about/credits.md
@@ -64,4 +64,4 @@ License by repository:
 - **Azazel-Edge**: MIT
 - **Azazel-Gadget**: MIT
 - **Azazel-Knowledge**: MIT
-- **Azazel-Fabric**: TBD
+- **Azazel-Fabric**: MIT

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,8 @@ nav_exclude: false
   <p class="az-badges">
     <a href="https://github.com/01rabbit/Azazel-Edge/releases"><img alt="Azazel-Edge release" src="https://img.shields.io/github/v/release/01rabbit/Azazel-Edge?display_name=tag&label=Azazel-Edge&color=00c2d7"></a>
     <a href="https://github.com/01rabbit/Azazel-Gadget/releases"><img alt="Azazel-Gadget release" src="https://img.shields.io/github/v/release/01rabbit/Azazel-Gadget?display_name=tag&label=Azazel-Gadget&color=00c2d7"></a>
+    <a href="https://github.com/01rabbit/Azazel-Knowledge/actions"><img alt="Azazel-Knowledge CI" src="https://img.shields.io/github/actions/workflow/status/01rabbit/Azazel-Knowledge/test.yml?label=Azazel-Knowledge%20CI"></a>
+    <a href="https://github.com/01rabbit/Azazel-Fabric/releases"><img alt="Azazel-Fabric release" src="https://img.shields.io/github/v/release/01rabbit/Azazel-Fabric?display_name=tag&label=Azazel-Fabric&color=00c2d7"></a>
   </p>
   <div class="az-loop">
     <span class="az-loop-step">Detect</span>
@@ -69,7 +71,7 @@ nav_exclude: false
       <li><code>Azazel-Edge</code>: MIT</li>
       <li><code>Azazel-Gadget</code>: MIT</li>
       <li><code>Azazel-Knowledge</code>: MIT</li>
-      <li><code>Azazel-Fabric</code>: TBD</li>
+      <li><code>Azazel-Fabric</code>: MIT</li>
     </ul>
   </section>
 </div>

--- a/docs/index_ja.md
+++ b/docs/index_ja.md
@@ -12,6 +12,8 @@ nav_exclude: true
   <p class="az-badges">
     <a href="https://github.com/01rabbit/Azazel-Edge/releases"><img alt="Azazel-Edge release" src="https://img.shields.io/github/v/release/01rabbit/Azazel-Edge?display_name=tag&label=Azazel-Edge&color=00c2d7"></a>
     <a href="https://github.com/01rabbit/Azazel-Gadget/releases"><img alt="Azazel-Gadget release" src="https://img.shields.io/github/v/release/01rabbit/Azazel-Gadget?display_name=tag&label=Azazel-Gadget&color=00c2d7"></a>
+    <a href="https://github.com/01rabbit/Azazel-Knowledge/actions"><img alt="Azazel-Knowledge CI" src="https://img.shields.io/github/actions/workflow/status/01rabbit/Azazel-Knowledge/test.yml?label=Azazel-Knowledge%20CI"></a>
+    <a href="https://github.com/01rabbit/Azazel-Fabric/releases"><img alt="Azazel-Fabric release" src="https://img.shields.io/github/v/release/01rabbit/Azazel-Fabric?display_name=tag&label=Azazel-Fabric&color=00c2d7"></a>
   </p>
 </div>
 
@@ -55,7 +57,7 @@ nav_exclude: true
       <li><code>Azazel-Edge</code>: MIT</li>
       <li><code>Azazel-Gadget</code>: MIT</li>
       <li><code>Azazel-Knowledge</code>: MIT</li>
-      <li><code>Azazel-Fabric</code>: TBD</li>
+      <li><code>Azazel-Fabric</code>: MIT</li>
     </ul>
   </section>
 </div>

--- a/docs/products/azazel-fabric.md
+++ b/docs/products/azazel-fabric.md
@@ -37,6 +37,6 @@ The shared contracts library for the Azazel series — the common language spoke
 ## Package and License
 
 - Distribution name `azazel-fabric`, import as `azazel_fabric` (from v0.3.0; the v0.1.0/v0.2.0 tags keep the former `azazel-common` / `azazel_common` identifiers). Latest tagged release: v0.3.0.
-- License: TBD (no LICENSE file yet).
+- License: MIT.
 
 See also: [Product Map](product-map.md) | [Naming Convention](../specs/naming.md)


### PR DESCRIPTION
## Summary
- Change type: [x] Spec(ガバナンス文書+サイト表記)

シリーズ統一整備の傘リポジトリ分:

- **バッジ完成**: README / index.md / index_ja.md に Azazel-Fabric(release + release-date)と Azazel-Knowledge を追加。Knowledgeはリリース未発行のためreleaseバッジが壊れて表示される——**CI + last-commitバッジで代替**(リリース発行後にrelease系へ差し替え可)
- **ライセンスマトリクス**: Azazel-Fabric TBD → **MIT** を全箇所(README / index EN/JA / credits / 製品ページ)
- **SECURITY.md**: 4行スタブ→正典ポリシー(非公開Advisory報告・応答目標・ハブとしてのスコープ・製品リポジトリへのルーティング)
- **CONTRIBUTING.md**(新規): docsリポジトリ版の正典構造(命名規約遵守・JA鏡面同期・制限語)

## Checklist
- [x] Updated nav in `_config.yml` if needed — 不要
- [ ] Added/updated diagrams — 対象外
- [x] No broken internal links — 確認済み(残存TBDゼロもgrep確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQf8XoJkM1vVE57jAYmi94

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQf8XoJkM1vVE57jAYmi94)_